### PR TITLE
Restore fails

### DIFF
--- a/src/SimpleBackup.php
+++ b/src/SimpleBackup.php
@@ -231,6 +231,7 @@ class SimpleBackup
 
         $error_message = '';
         $error_status = false;
+        $line_number = 0;
 
         try {
             if (!empty($config)) {
@@ -262,6 +263,7 @@ class SimpleBackup
 
             // Loop through each line
             foreach ($allLines as $line) {
+				$line_number++;
 
                 // (if it is not a comment..) Add this line to the current segment
                 if ($line != '' && strpos($line, '--') !== 0) {
@@ -283,9 +285,13 @@ class SimpleBackup
             $error_status = true;
 
             $this->response = [
-                'status' => false,
-                'message' => $e->getMessage()
+                'status' => false
+                ,'message' => $e->getMessage()
+                ,'line_number' => $line_number
+                ,'query' => $templine
+                ,'error_message' => $error_message
             ];
+			return $this;
         }
 
         $this->response['message'] = $error_message;
@@ -293,6 +299,9 @@ class SimpleBackup
         if ($error_status === false) {
             $this->response['message'] = 'Importing finished successfully';
         }
+		else{
+			$this->response['message'] = 'Importing error';
+		}
 
         return $this;
     }


### PR DESCRIPTION
Updates to fix errors when executing SQL lines starting with description line.

BUT; there are still bugs.
**TRIGGER**s cannot be imported.

message | "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'DELIMITER $\rCREATE TRIGGER `trigger_name` AFTER INSERT ON `table1` FOR ...' at line 1"
--
line_number | 386
query | "DELIMITER $\rCREATE TRIGGER `trigger_name` AFTER INSERT ON `table1` FOR EACH ROW insert into table2 (id) values (new.id)\r$\rDELIMITER ;\r

MariaDB-10.4.27
mysqlnd 8.2.0
PHP version: 8.2.0