### PR TITLE
fix: Resolves PHP 8.3 deprecated notices.

### DIFF
--- a/src/Foundation/Mysqldump.php
+++ b/src/Foundation/Mysqldump.php
@@ -792,7 +792,7 @@ class Mysqldump
     {
         if (!$this->dumpSettings['skip-comments']) {
             $ret = "--" . PHP_EOL .
-                "-- Stand-In structure for view `${viewName}`" . PHP_EOL .
+                "-- Stand-In structure for view `{$viewName}`" . PHP_EOL .
                 "--" . PHP_EOL . PHP_EOL;
             $this->compressManager->write($ret);
         }
@@ -824,7 +824,7 @@ class Mysqldump
     {
         $ret = array();
         foreach ($this->tableColumnTypes[$viewName] as $k => $v) {
-            $ret[] = "`${k}` ${v['type_sql']}";
+            $ret[] = "`{$k}` {$v['type_sql']}";
         }
         $ret = implode(PHP_EOL . ",", $ret);
 
@@ -845,7 +845,7 @@ class Mysqldump
     {
         if (!$this->dumpSettings['skip-comments']) {
             $ret = "--" . PHP_EOL .
-                "-- View structure for view `${viewName}`" . PHP_EOL .
+                "-- View structure for view `{$viewName}`" . PHP_EOL .
                 "--" . PHP_EOL . PHP_EOL;
             $this->compressManager->write($ret);
         }
@@ -968,7 +968,7 @@ class Mysqldump
             return "NULL";
         } elseif ($this->dumpSettings['hex-blob'] && $colType['is_blob']) {
             if ($colType['type'] == 'bit' || !empty($colValue)) {
-                return "0x${colValue}";
+                return "0x{$colValue}";
             } else {
                 return "''";
             }
@@ -1201,14 +1201,14 @@ class Mysqldump
         $colStmt = array();
         foreach ($this->tableColumnTypes[$tableName] as $colName => $colType) {
             if ($colType['type'] == 'bit' && $this->dumpSettings['hex-blob']) {
-                $colStmt[] = "LPAD(HEX(`${colName}`),2,'0') AS `${colName}`";
+                $colStmt[] = "LPAD(HEX(`{$colName}`),2,'0') AS `{$colName}`";
             } elseif ($colType['is_blob'] && $this->dumpSettings['hex-blob']) {
-                $colStmt[] = "HEX(`${colName}`) AS `${colName}`";
+                $colStmt[] = "HEX(`{$colName}`) AS `{$colName}`";
             } elseif ($colType['is_virtual']) {
                 $this->dumpSettings['complete-insert'] = true;
                 continue;
             } else {
-                $colStmt[] = "`${colName}`";
+                $colStmt[] = "`{$colName}`";
             }
         }
 
@@ -1230,7 +1230,7 @@ class Mysqldump
                 $this->dumpSettings['complete-insert'] = true;
                 continue;
             } else {
-                $colNames[] = "`${colName}`";
+                $colNames[] = "`{$colName}`";
             }
         }
         return $colNames;
@@ -1526,7 +1526,7 @@ abstract class TypeAdapterFactory
 
         $args = func_get_args();
 
-        return "pragma table_info(${args[0]})";
+        return "pragma table_info({$args[0]})";
     }
 
     public function show_procedures()
@@ -1701,10 +1701,10 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $resultSet->closeCursor();
         $ret = "";
 
-        $ret .= "CREATE DATABASE /* !32312 IF NOT EXISTS*/ `${databaseName}`" .
-            " /* !40100 DEFAULT CHARACTER SET ${characterSet} " .
-            " COLLATE ${collationDb} */;" . PHP_EOL . PHP_EOL .
-            "USE `${databaseName}`;" . PHP_EOL . PHP_EOL;
+        $ret .= "CREATE DATABASE /* !32312 IF NOT EXISTS*/ `{$databaseName}`" .
+            " /* !40100 DEFAULT CHARACTER SET {$characterSet} " .
+            " COLLATE {$collationDb} */;" . PHP_EOL . PHP_EOL .
+            "USE `{$databaseName}`;" . PHP_EOL . PHP_EOL;
 
         return $ret;
     }
@@ -1880,7 +1880,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT TABLE_NAME AS tbl_name " .
             "FROM INFORMATION_SCHEMA.TABLES " .
-            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='${args[0]}'";
+            "WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='{$args[0]}'";
     }
 
     public function show_views()
@@ -1889,21 +1889,21 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT TABLE_NAME AS tbl_name " .
             "FROM INFORMATION_SCHEMA.TABLES " .
-            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA='${args[0]}'";
+            "WHERE TABLE_TYPE='VIEW' AND TABLE_SCHEMA='{$args[0]}'";
     }
 
     public function show_triggers()
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "SHOW TRIGGERS FROM `${args[0]}`;";
+        return "SHOW TRIGGERS FROM `{$args[0]}`;";
     }
 
     public function show_columns()
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "SHOW COLUMNS FROM `${args[0]}`;";
+        return "SHOW COLUMNS FROM `{$args[0]}`;";
     }
 
     public function show_procedures()
@@ -1912,7 +1912,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT SPECIFIC_NAME AS procedure_name " .
             "FROM INFORMATION_SCHEMA.ROUTINES " .
-            "WHERE ROUTINE_TYPE='PROCEDURE' AND ROUTINE_SCHEMA='${args[0]}'";
+            "WHERE ROUTINE_TYPE='PROCEDURE' AND ROUTINE_SCHEMA='{$args[0]}'";
     }
 
     /**
@@ -1927,7 +1927,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $args = func_get_args();
         return "SELECT EVENT_NAME AS event_name " .
             "FROM INFORMATION_SCHEMA.EVENTS " .
-            "WHERE EVENT_SCHEMA='${args[0]}'";
+            "WHERE EVENT_SCHEMA='{$args[0]}'";
     }
 
     public function setup_transaction()
@@ -1949,7 +1949,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return $this->dbHandler->exec("LOCK TABLES `${args[0]}` READ LOCAL");
+        return $this->dbHandler->exec("LOCK TABLES `{$args[0]}` READ LOCAL");
     }
 
     public function unlock_table()
@@ -1961,7 +1961,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "LOCK TABLES `${args[0]}` WRITE;" . PHP_EOL;
+        return "LOCK TABLES `{$args[0]}` WRITE;" . PHP_EOL;
     }
 
     public function end_add_lock_table()
@@ -1973,7 +1973,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "/* !40000 ALTER TABLE `${args[0]}` DISABLE KEYS */;" .
+        return "/* !40000 ALTER TABLE `{$args[0]}` DISABLE KEYS */;" .
             PHP_EOL;
     }
 
@@ -1981,7 +1981,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "/* !40000 ALTER TABLE `${args[0]}` ENABLE KEYS */;" .
+        return "/* !40000 ALTER TABLE `{$args[0]}` ENABLE KEYS */;" .
             PHP_EOL;
     }
 
@@ -1999,7 +1999,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "/* !40000 DROP DATABASE IF EXISTS `${args[0]}`*/;" .
+        return "/* !40000 DROP DATABASE IF EXISTS `{$args[0]}`*/;" .
             PHP_EOL . PHP_EOL;
     }
 
@@ -2007,22 +2007,22 @@ class TypeAdapterMysql extends TypeAdapterFactory
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "DROP TRIGGER IF EXISTS `${args[0]}`;" . PHP_EOL;
+        return "DROP TRIGGER IF EXISTS `{$args[0]}`;" . PHP_EOL;
     }
 
     public function drop_table()
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "DROP TABLE IF EXISTS `${args[0]}`;" . PHP_EOL;
+        return "DROP TABLE IF EXISTS `{$args[0]}`;" . PHP_EOL;
     }
 
     public function drop_view()
     {
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
-        return "DROP TABLE IF EXISTS `${args[0]}`;" . PHP_EOL .
-            "/* !50001 DROP VIEW IF EXISTS `${args[0]}`*/;" . PHP_EOL;
+        return "DROP TABLE IF EXISTS `{$args[0]}`;" . PHP_EOL .
+            "/* !50001 DROP VIEW IF EXISTS `{$args[0]}`*/;" . PHP_EOL;
     }
 
     public function getDatabaseHeader()
@@ -2030,7 +2030,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         $this->check_parameters(func_num_args(), $expected_num_args = 1, __METHOD__);
         $args = func_get_args();
         return "--" . PHP_EOL .
-            "-- Current Database: `${args[0]}`" . PHP_EOL .
+            "-- Current Database: `{$args[0]}`" . PHP_EOL .
             "--" . PHP_EOL . PHP_EOL;
     }
 


### PR DESCRIPTION
This fix resolve the PHP 8.3 deprecation errors in the Mysqldump class. 

Error: "Using ${} in strings is deprecated."